### PR TITLE
Refs #101692 force https rewrite for ++ links

### DIFF
--- a/src/vh-www-common.inc
+++ b/src/vh-www-common.inc
@@ -145,7 +145,7 @@
     RewriteCond %{REQUEST_URI} !\.gif$
     RewriteCond %{REQUEST_URI} !\.css$
     RewriteCond %{REQUEST_URI} !\.js$
-    RewriteRule ^/\+\+(.*) /www/++$1 [R=permanent,L,NE]
+    RewriteRule ^/\+\+(.*)  https://%{HTTP_HOST}/www/++$1 [R=permanent,L,NE]
 
     RewriteCond %{REQUEST_URI} !^/@@rdf
     RewriteCond %{REQUEST_URI} !^/@@eea\.controlpanel


### PR DESCRIPTION
This avoids an extra redirect from http to https which breaks jQuery ajax load
due to security headers